### PR TITLE
feat: core Web API endpoints

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,11 +1,32 @@
 import { WebApiClient, WebApiClientConfig } from './web/web-client.js';
+import { PlayersEndpoints } from './web/players.js';
+import { StandingsEndpoints } from './web/standings.js';
+import { ScoresEndpoints } from './web/scores.js';
+import { TeamsEndpoints } from './web/teams.js';
+import { ScheduleEndpoints } from './web/schedule.js';
+import { GamesEndpoints } from './web/games.js';
+import { LeadersEndpoints } from './web/leaders.js';
 
 export interface NHLClientConfig extends WebApiClientConfig {}
 
 export class NHLClient {
   public readonly web: WebApiClient;
+  public readonly players: PlayersEndpoints;
+  public readonly standings: StandingsEndpoints;
+  public readonly scores: ScoresEndpoints;
+  public readonly teams: TeamsEndpoints;
+  public readonly schedule: ScheduleEndpoints;
+  public readonly games: GamesEndpoints;
+  public readonly leaders: LeadersEndpoints;
 
   constructor(config?: NHLClientConfig) {
     this.web = new WebApiClient(config);
+    this.players = this.web.players;
+    this.standings = this.web.standings;
+    this.scores = this.web.scores;
+    this.teams = this.web.teams;
+    this.schedule = this.web.schedule;
+    this.games = this.web.games;
+    this.leaders = this.web.leaders;
   }
 }

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -1,0 +1,366 @@
+import { LocalizedName, PlayerRef } from './common.js';
+
+export interface Boxscore {
+  id: number;
+  season: number;
+  gameType: number;
+  gameDate: string;
+  venue: LocalizedName;
+  startTimeUTC: string;
+  easternUTCOffset: string;
+  venueUTCOffset: string;
+  gameState: string;
+  gameScheduleState: string;
+  periodDescriptor: {
+    number: number;
+    periodType: string;
+    maxRegulationPeriods: number;
+  };
+  awayTeam: BoxscoreTeam;
+  homeTeam: BoxscoreTeam;
+  clock?: GameClock;
+  playerByGameStats: PlayerByGameStats;
+  boxscore: BoxscoreDetails;
+  gameVideo?: GameVideo;
+}
+
+export interface BoxscoreTeam {
+  id: number;
+  name: LocalizedName;
+  abbrev: string;
+  score: number;
+  sog: number;
+  faceoffWinningPctg?: number;
+  powerPlay?: string;
+  pim?: number;
+  hits?: number;
+  blocks?: number;
+  logo: string;
+}
+
+export interface GameClock {
+  timeRemaining: string;
+  secondsRemaining: number;
+  running: boolean;
+  inIntermission: boolean;
+}
+
+export interface PlayerByGameStats {
+  awayTeam: TeamGameStats;
+  homeTeam: TeamGameStats;
+}
+
+export interface TeamGameStats {
+  forwards: PlayerGameStat[];
+  defense: PlayerGameStat[];
+  goalies: GoalieGameStat[];
+}
+
+export interface PlayerGameStat {
+  playerId: number;
+  name: LocalizedName;
+  sweaterNumber: number;
+  position: string;
+  goals: number;
+  assists: number;
+  points: number;
+  plusMinus: number;
+  pim: number;
+  hits: number;
+  blockedShots: number;
+  powerPlayGoals: number;
+  powerPlayPoints: number;
+  shorthandedGoals: number;
+  shorthpiandedPoints: number;
+  shots: number;
+  faceoffs: string;
+  faceoffWinningPctg: number;
+  toi: string;
+  powerPlayToi: string;
+  shorthandedToi: string;
+}
+
+export interface GoalieGameStat {
+  playerId: number;
+  name: LocalizedName;
+  sweaterNumber: number;
+  position: string;
+  evenStrengthShotsAgainst: string;
+  powerPlayShotsAgainst: string;
+  shorthandedShotsAgainst: string;
+  saveShotsAgainst: string;
+  savePctg?: number;
+  evenStrengthGoalsAgainst: number;
+  powerPlayGoalsAgainst: number;
+  shorthandedGoalsAgainst: number;
+  pim: number;
+  goalsAgainst: number;
+  toi: string;
+}
+
+export interface BoxscoreDetails {
+  linescore: Linescore;
+  shotsByPeriod: ShotsByPeriod[];
+  gameReports?: GameReports;
+}
+
+export interface Linescore {
+  byPeriod: PeriodScore[];
+  totals: { away: number; home: number };
+}
+
+export interface PeriodScore {
+  period: number;
+  periodDescriptor: { number: number; periodType: string };
+  away: number;
+  home: number;
+}
+
+export interface ShotsByPeriod {
+  period: number;
+  periodDescriptor: { number: number; periodType: string };
+  away: number;
+  home: number;
+}
+
+export interface GameReports {
+  gameSummary?: string;
+  eventSummary?: string;
+  playByPlay?: string;
+  faceoffSummary?: string;
+  faceoffComparison?: string;
+  rosters?: string;
+  shotSummary?: string;
+  shiftChart?: string;
+  toiAway?: string;
+  toiHome?: string;
+}
+
+export interface GameVideo {
+  threeMinRecap?: number;
+  threeMinRecapFr?: number;
+  condensedGame?: number;
+  condensedGameFr?: number;
+}
+
+export interface PlayByPlay {
+  id: number;
+  season: number;
+  gameType: number;
+  gameDate: string;
+  venue: LocalizedName;
+  startTimeUTC: string;
+  gameState: string;
+  gameScheduleState: string;
+  awayTeam: { id: number; abbrev: string; logo: string; score?: number };
+  homeTeam: { id: number; abbrev: string; logo: string; score?: number };
+  clock?: GameClock;
+  periodDescriptor?: { number: number; periodType: string; maxRegulationPeriods: number };
+  plays: Play[];
+  rosterSpots: RosterSpot[];
+}
+
+export interface Play {
+  eventId: number;
+  periodDescriptor: { number: number; periodType: string };
+  timeInPeriod: string;
+  timeRemaining: string;
+  situationCode?: string;
+  homeTeamDefendingSide?: string;
+  typeCode: number;
+  typeDescKey: string;
+  sortOrder: number;
+  details?: Record<string, unknown>;
+}
+
+export interface RosterSpot {
+  teamId: number;
+  playerId: number;
+  firstName: LocalizedName;
+  lastName: LocalizedName;
+  sweaterNumber: number;
+  positionCode: string;
+  headshot: string;
+}
+
+export interface GameLanding {
+  id: number;
+  season: number;
+  gameType: number;
+  gameDate: string;
+  venue: LocalizedName;
+  startTimeUTC: string;
+  gameState: string;
+  gameScheduleState: string;
+  awayTeam: GameLandingTeam;
+  homeTeam: GameLandingTeam;
+  summary?: GameSummary;
+  matchup?: Record<string, unknown>;
+}
+
+export interface GameLandingTeam {
+  id: number;
+  name: LocalizedName;
+  abbrev: string;
+  score?: number;
+  sog?: number;
+  logo: string;
+}
+
+export interface GameSummary {
+  scoring: ScoringPeriod[];
+  shootout?: ShootoutAttempt[];
+  threeStars?: ThreeStar[];
+  penalties: PenaltyPeriod[];
+  gameInfo?: Record<string, unknown>;
+  linescore?: Linescore;
+  shotsByPeriod?: ShotsByPeriod[];
+}
+
+export interface ScoringPeriod {
+  periodDescriptor: { number: number; periodType: string };
+  goals: ScoringGoal[];
+}
+
+export interface ScoringGoal {
+  situationCode: string;
+  strength: string;
+  playerId: number;
+  firstName: LocalizedName;
+  lastName: LocalizedName;
+  name?: LocalizedName;
+  teamAbbrev: LocalizedName;
+  headshot: string;
+  highlightClip?: number;
+  highlightClipFr?: number;
+  goalsToDate: number;
+  awayScore: number;
+  homeScore: number;
+  leadingTeamAbbrev?: LocalizedName;
+  timeInPeriod: string;
+  shotType?: string;
+  goalModifier?: string;
+  assists: ScoringAssist[];
+}
+
+export interface ScoringAssist {
+  playerId: number;
+  firstName: LocalizedName;
+  lastName: LocalizedName;
+  name?: LocalizedName;
+  assistsToDate: number;
+}
+
+export interface ShootoutAttempt {
+  sequence: number;
+  playerId: number;
+  teamAbbrev: string;
+  firstName: LocalizedName;
+  lastName: LocalizedName;
+  shotType?: string;
+  result: string;
+  headshot: string;
+  gameWinner: boolean;
+}
+
+export interface ThreeStar {
+  star: number;
+  playerId: number;
+  teamAbbrev: string;
+  headshot: string;
+  name: LocalizedName;
+  firstName: LocalizedName;
+  lastName: LocalizedName;
+  sweaterNo: number;
+  position: string;
+  goals?: number;
+  assists?: number;
+  points?: number;
+  savePctg?: number;
+  goalsAgainst?: number;
+}
+
+export interface PenaltyPeriod {
+  periodDescriptor: { number: number; periodType: string };
+  penalties: PenaltyEvent[];
+}
+
+export interface PenaltyEvent {
+  timeInPeriod: string;
+  type: string;
+  duration: number;
+  committedByPlayer?: string;
+  teamAbbrev: LocalizedName;
+  drawnBy?: string;
+  descKey: string;
+}
+
+export interface ScoresResponse {
+  currentDate: string;
+  prevDate: string;
+  nextDate: string;
+  gamesByDate: GamesByDate[];
+  focusedDate?: string;
+  focusedDateCount?: number;
+}
+
+export interface GamesByDate {
+  date: string;
+  games: ScoreGame[];
+}
+
+export interface ScoreGame {
+  id: number;
+  season: number;
+  gameType: number;
+  venue: LocalizedName;
+  neutralSite: boolean;
+  startTimeUTC: string;
+  easternUTCOffset: string;
+  venueUTCOffset: string;
+  venueTimezone: string;
+  gameState: string;
+  gameScheduleState: string;
+  awayTeam: ScoreTeam;
+  homeTeam: ScoreTeam;
+  periodDescriptor?: { number: number; periodType: string; maxRegulationPeriods: number };
+  gameOutcome?: { lastPeriodType: string };
+  clock?: GameClock;
+  gameCenterLink: string;
+  [key: string]: unknown;
+}
+
+export interface ScoreTeam {
+  id: number;
+  abbrev: string;
+  logo: string;
+  darkLogo?: string;
+  score?: number;
+}
+
+export interface GameStory {
+  id: number;
+  season: number;
+  gameType: number;
+  gameDate: string;
+  venue: LocalizedName;
+  gameState: string;
+  awayTeam: GameLandingTeam;
+  homeTeam: GameLandingTeam;
+  summary?: GameSummary;
+  [key: string]: unknown;
+}
+
+export interface GameRightRail {
+  gameId: number;
+  teamGameStats?: TeamGameStatsComparison[];
+  seasonSeriesWins?: Record<string, unknown>;
+  shotsByPeriod?: ShotsByPeriod[];
+  [key: string]: unknown;
+}
+
+export interface TeamGameStatsComparison {
+  category: string;
+  awayValue: string | number;
+  homeValue: string | number;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,7 @@
 export * from './common.js';
+export * from './player.js';
+export * from './standings.js';
+export * from './schedule.js';
+export * from './game.js';
+export * from './team.js';
+export * from './leaders.js';

--- a/src/types/leaders.ts
+++ b/src/types/leaders.ts
@@ -1,0 +1,24 @@
+import { LocalizedName } from './common.js';
+
+export interface LeadersResponse {
+  categories: LeaderCategory[];
+}
+
+export interface LeaderCategory {
+  categoryKey: string;
+  displayTitle: string;
+  leaders: Leader[];
+}
+
+export interface Leader {
+  id: number;
+  firstName: LocalizedName;
+  lastName: LocalizedName;
+  sweaterNumber: number;
+  teamAbbrev: string;
+  teamName?: LocalizedName;
+  teamLogo: string;
+  headshot: string;
+  position: string;
+  value: number | string;
+}

--- a/src/types/player.ts
+++ b/src/types/player.ts
@@ -1,0 +1,137 @@
+import { LocalizedName, TeamRef } from './common.js';
+
+export interface PlayerLanding {
+  playerId: number;
+  isActive: boolean;
+  currentTeamId?: number;
+  currentTeamAbbrev?: string;
+  fullTeamName?: LocalizedName;
+  firstName: LocalizedName;
+  lastName: LocalizedName;
+  teamLogo?: string;
+  sweaterNumber?: number;
+  position: string;
+  headshot: string;
+  heroImage?: string;
+  heightInInches?: number;
+  weightInPounds?: number;
+  heightInCentimeters?: number;
+  weightInKilograms?: number;
+  birthDate: string;
+  birthCity?: LocalizedName;
+  birthStateProvince?: LocalizedName;
+  birthCountry: string;
+  shootsCatches: string;
+  draftDetails?: DraftDetails;
+  playerSlug: string;
+  inTop100AllTime?: number;
+  inHHOF?: number;
+  featuredStats?: FeaturedStats;
+  careerTotals?: CareerTotals;
+  shopLink?: string;
+  twitterLink?: string;
+  watchLink?: string;
+  last5Games?: GameLogEntry[];
+  seasonTotals?: SeasonTotal[];
+  awards?: Award[];
+  currentTeamRoster?: RosterEntry[];
+}
+
+export interface DraftDetails {
+  year: number;
+  teamAbbrev: string;
+  round: number;
+  pickInRound: number;
+  overallPick: number;
+}
+
+export interface FeaturedStats {
+  season: number;
+  regularSeason?: StatsSummary;
+  playoffs?: StatsSummary;
+}
+
+export interface StatsSummary {
+  subSeason: Record<string, number | string>;
+  career: Record<string, number | string>;
+}
+
+export interface CareerTotals {
+  regularSeason?: Record<string, number>;
+  playoffs?: Record<string, number>;
+}
+
+export interface GameLogEntry {
+  gameId: number;
+  teamAbbrev: string;
+  homeRoadFlag: string;
+  gameDate: string;
+  goals?: number;
+  assists?: number;
+  points?: number;
+  plusMinus?: number;
+  powerPlayGoals?: number;
+  shots?: number;
+  shifts?: number;
+  shorthandedGoals?: number;
+  gameWinningGoals?: number;
+  otGoals?: number;
+  pim?: number;
+  toi?: string;
+  // Goalie fields
+  gamesStarted?: number;
+  decision?: string;
+  shotsAgainst?: number;
+  goalsAgainst?: number;
+  savePctg?: number;
+  shutouts?: number;
+}
+
+export interface SeasonTotal {
+  season: number;
+  gameTypeId: number;
+  leagueAbbrev: string;
+  teamName: LocalizedName;
+  sequence?: number;
+  gamesPlayed: number;
+  [key: string]: unknown;
+}
+
+export interface Award {
+  trophy: LocalizedName;
+  seasons: AwardSeason[];
+}
+
+export interface AwardSeason {
+  seasonId: number;
+  gamesPlayed: number;
+  [key: string]: unknown;
+}
+
+export interface RosterEntry {
+  playerId: number;
+  lastName: LocalizedName;
+  firstName: LocalizedName;
+  playerSlug: string;
+}
+
+export interface PlayerGameLog {
+  seasonId: number;
+  gameTypeId: number;
+  playerStatsSeasons?: number[];
+  gameLog: GameLogEntry[];
+}
+
+export interface PlayerSpotlight {
+  playerId: number;
+  name: LocalizedName;
+  firstName: LocalizedName;
+  lastName: LocalizedName;
+  sweaterNumber: number;
+  position: string;
+  headshot: string;
+  teamTriCode: string;
+  teamLogo: string;
+  teamId: number;
+  [key: string]: unknown;
+}

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -1,0 +1,106 @@
+import { LocalizedName, TeamRef } from './common.js';
+
+export interface ScheduleResponse {
+  nextStartDate: string;
+  previousStartDate: string;
+  gameWeek: GameWeek[];
+  oddsPartners: OddsPartner[];
+  preSeasonStartDate: string;
+  regularSeasonStartDate: string;
+  regularSeasonEndDate: string;
+  playoffEndDate: string;
+  numberOfGames: number;
+}
+
+export interface GameWeek {
+  date: string;
+  dayAbbrev: string;
+  numberOfGames: number;
+  games: ScheduleGame[];
+}
+
+export interface ScheduleGame {
+  id: number;
+  season: number;
+  gameType: number;
+  venue: LocalizedName;
+  neutralSite: boolean;
+  startTimeUTC: string;
+  easternUTCOffset: string;
+  venueUTCOffset: string;
+  venueTimezone: string;
+  gameState: string;
+  gameScheduleState: string;
+  tvBroadcasts: TvBroadcast[];
+  awayTeam: ScheduleTeam;
+  homeTeam: ScheduleTeam;
+  periodDescriptor?: PeriodDescriptor;
+  gameOutcome?: GameOutcome;
+  winningGoalie?: PlayerInfo;
+  winningGoalScorer?: PlayerInfo;
+  threeMinRecap?: string;
+  threeMinRecapFr?: string;
+  gameCenterLink: string;
+  ticketsLink?: string;
+  ticketsLinkFr?: string;
+}
+
+export interface ScheduleTeam {
+  id: number;
+  placeName?: LocalizedName;
+  abbrev: string;
+  logo: string;
+  darkLogo: string;
+  awaySplitSquad?: boolean;
+  homeSplitSquad?: boolean;
+  score?: number;
+  radioLink?: string;
+  odds?: OddsEntry[];
+}
+
+export interface TvBroadcast {
+  id: number;
+  market: string;
+  countryCode: string;
+  network: string;
+  sequenceNumber: number;
+}
+
+export interface PeriodDescriptor {
+  number: number;
+  periodType: string;
+  maxRegulationPeriods?: number;
+}
+
+export interface GameOutcome {
+  lastPeriodType: string;
+}
+
+export interface PlayerInfo {
+  playerId: number;
+  firstInitial: LocalizedName;
+  lastName: LocalizedName;
+}
+
+export interface OddsPartner {
+  partnerId: number;
+  country: string;
+  name: string;
+  imageUrl: string;
+  siteUrl?: string;
+  bgColor: string;
+  textColor: string;
+  accentColor: string;
+}
+
+export interface OddsEntry {
+  providerId: number;
+  value: string;
+}
+
+export interface ScheduleCalendar {
+  nextStartDate: string;
+  previousStartDate: string;
+  clubTimeZone?: string;
+  clubUTCOffset?: string;
+}

--- a/src/types/standings.ts
+++ b/src/types/standings.ts
@@ -1,0 +1,98 @@
+import { LocalizedName } from './common.js';
+
+export interface StandingsResponse {
+  wildCardIndicator: boolean;
+  standings: StandingEntry[];
+}
+
+export interface StandingEntry {
+  conferenceAbbrev: string;
+  conferenceName: string;
+  conferenceSequence: number;
+  divisionAbbrev: string;
+  divisionName: string;
+  divisionSequence: number;
+  teamName: LocalizedName;
+  teamCommonName: LocalizedName;
+  teamAbbrev: LocalizedName;
+  teamLogo: string;
+  clinchIndicator?: string;
+  date: string;
+  gamesPlayed: number;
+  goalDifferential: number;
+  goalDifferentialPctg: number;
+  goalAgainst: number;
+  goalFor: number;
+  goalsForPctg: number;
+  homeGamesPlayed: number;
+  homeGoalDifferential: number;
+  homeGoalsAgainst: number;
+  homeGoalsFor: number;
+  homeLosses: number;
+  homeOtLosses: number;
+  homePoints: number;
+  homeRegulationPlusOtWins: number;
+  homeRegulationWins: number;
+  homeTies?: number;
+  homeWins: number;
+  l10GamesPlayed: number;
+  l10GoalDifferential: number;
+  l10GoalsAgainst: number;
+  l10GoalsFor: number;
+  l10Losses: number;
+  l10OtLosses: number;
+  l10Points: number;
+  l10RegulationPlusOtWins: number;
+  l10RegulationWins: number;
+  l10Ties?: number;
+  l10Wins: number;
+  leagueHomeSequence: number;
+  leagueL10Sequence: number;
+  leagueRoadSequence: number;
+  leagueSequence: number;
+  losses: number;
+  otLosses: number;
+  placeName: LocalizedName;
+  pointPctg: number;
+  points: number;
+  regulationPlusOtWinPctg: number;
+  regulationPlusOtWins: number;
+  regulationWinPctg: number;
+  regulationWins: number;
+  roadGamesPlayed: number;
+  roadGoalDifferential: number;
+  roadGoalsAgainst: number;
+  roadGoalsFor: number;
+  roadLosses: number;
+  roadOtLosses: number;
+  roadPoints: number;
+  roadRegulationPlusOtWins: number;
+  roadRegulationWins: number;
+  roadTies?: number;
+  roadWins: number;
+  seasonId: number;
+  streakCode: string;
+  streakCount: number;
+  ties?: number;
+  waiversSequence: number;
+  wildcardSequence: number;
+  winPctg: number;
+  wins: number;
+}
+
+export interface StandingsSeasonList {
+  seasons: StandingsSeason[];
+}
+
+export interface StandingsSeason {
+  id: number;
+  conferencesInUse: boolean;
+  divisionsInUse: boolean;
+  pointForOTLossInUse: boolean;
+  regulationWinsInUse: boolean;
+  rowInUse: boolean;
+  standingsEnd: string;
+  standingsStart: string;
+  tiesInUse: boolean;
+  wildcardInUse: boolean;
+}

--- a/src/types/team.ts
+++ b/src/types/team.ts
@@ -1,0 +1,148 @@
+import { LocalizedName, PlayerRef } from './common.js';
+
+export interface TeamRoster {
+  forwards: RosterPlayer[];
+  defensemen: RosterPlayer[];
+  goalies: RosterPlayer[];
+}
+
+export interface RosterPlayer {
+  id: number;
+  headshot: string;
+  firstName: LocalizedName;
+  lastName: LocalizedName;
+  sweaterNumber: number;
+  positionCode: string;
+  shootsCatches: string;
+  heightInInches: number;
+  weightInPounds: number;
+  heightInCentimeters: number;
+  weightInKilograms: number;
+  birthDate: string;
+  birthCity: LocalizedName;
+  birthCountry: string;
+  birthStateProvince?: LocalizedName;
+}
+
+export interface TeamSeasonStats {
+  season: number;
+  gameType: number;
+  teamId: number;
+  teamFullName: string;
+  skaters: TeamSkaterStat[];
+  goalies: TeamGoalieStat[];
+}
+
+export interface TeamSkaterStat {
+  playerId: number;
+  headshot: string;
+  firstName: LocalizedName;
+  lastName: LocalizedName;
+  positionCode: string;
+  gamesPlayed: number;
+  goals: number;
+  assists: number;
+  points: number;
+  plusMinus: number;
+  pim: number;
+  gameWinningGoals: number;
+  otGoals: number;
+  shots: number;
+  shootingPctg: number;
+  powerPlayGoals: number;
+  powerPlayPoints: number;
+  shorthandedGoals: number;
+  shorthandedPoints: number;
+  avgToi: string;
+  faceoffWinPctg: number;
+  [key: string]: unknown;
+}
+
+export interface TeamGoalieStat {
+  playerId: number;
+  headshot: string;
+  firstName: LocalizedName;
+  lastName: LocalizedName;
+  gamesPlayed: number;
+  gamesStarted: number;
+  wins: number;
+  losses: number;
+  otLosses: number;
+  goalsAgainstAvg: number;
+  savePctg: number;
+  shutouts: number;
+  [key: string]: unknown;
+}
+
+export interface TeamScheduleResponse {
+  previousMonth: string;
+  currentMonth: string;
+  nextMonth: string;
+  calendarUrl: string;
+  clubTimezone: string;
+  clubUTCOffset: string;
+  games: TeamScheduleGame[];
+}
+
+export interface TeamScheduleGame {
+  id: number;
+  season: number;
+  gameType: number;
+  gameDate: string;
+  venue: LocalizedName;
+  neutralSite: boolean;
+  startTimeUTC: string;
+  gameState: string;
+  gameScheduleState: string;
+  awayTeam: TeamScheduleTeamEntry;
+  homeTeam: TeamScheduleTeamEntry;
+  periodDescriptor?: { number: number; periodType: string };
+  gameOutcome?: { lastPeriodType: string };
+  winningGoalie?: { playerId: number };
+  winningGoalScorer?: { playerId: number };
+  tvBroadcasts?: { id: number; market: string; countryCode: string; network: string }[];
+  gameCenterLink: string;
+  ticketsLink?: string;
+}
+
+export interface TeamScheduleTeamEntry {
+  id: number;
+  abbrev: string;
+  logo: string;
+  darkLogo?: string;
+  score?: number;
+  placeName?: LocalizedName;
+  placeNameWithPreposition?: LocalizedName;
+}
+
+export interface ProspectStats {
+  [key: string]: unknown;
+}
+
+export interface TeamScoreboard {
+  focusedDate: string;
+  focusedDateCount: number;
+  clubTimeZone: string;
+  clubUTCOffset: string;
+  clubScheduleLink: string;
+  gamesByDate: GamesByDateEntry[];
+}
+
+export interface GamesByDateEntry {
+  date: string;
+  games: ScoreboardGame[];
+}
+
+export interface ScoreboardGame {
+  id: number;
+  season: number;
+  gameType: number;
+  gameDate: string;
+  startTimeUTC: string;
+  gameState: string;
+  gameScheduleState: string;
+  awayTeam: { id: number; abbrev: string; logo: string; score?: number };
+  homeTeam: { id: number; abbrev: string; logo: string; score?: number };
+  clock?: { timeRemaining: string; secondsRemaining: number; running: boolean; inIntermission: boolean };
+  [key: string]: unknown;
+}

--- a/src/web/games.ts
+++ b/src/web/games.ts
@@ -1,0 +1,34 @@
+import { HttpClient } from '../http/http-client.js';
+import { PlayByPlay, Boxscore, GameLanding, GameStory, GameRightRail } from '../types/game.js';
+
+export class GamesEndpoints {
+  constructor(private http: HttpClient) {}
+
+  async getPlayByPlay(gameId: number): Promise<PlayByPlay> {
+    return this.http.get<PlayByPlay>(`/gamecenter/${gameId}/play-by-play`);
+  }
+
+  async getBoxscore(gameId: number): Promise<Boxscore> {
+    return this.http.get<Boxscore>(`/gamecenter/${gameId}/boxscore`);
+  }
+
+  async getLanding(gameId: number): Promise<GameLanding> {
+    return this.http.get<GameLanding>(`/gamecenter/${gameId}/landing`);
+  }
+
+  async getStory(gameId: number): Promise<GameStory> {
+    return this.http.get<GameStory>(`/wsc/game-story/${gameId}`);
+  }
+
+  async getRightRail(gameId: number): Promise<GameRightRail> {
+    return this.http.get<GameRightRail>(`/gamecenter/${gameId}/right-rail`);
+  }
+
+  async getReplay(gameId: number): Promise<unknown> {
+    return this.http.get(`/gamecenter/${gameId}/recap`);
+  }
+
+  async getWscPlayByPlay(gameId: number): Promise<unknown> {
+    return this.http.get(`/wsc/game-play-by-play/${gameId}`);
+  }
+}

--- a/src/web/leaders.ts
+++ b/src/web/leaders.ts
@@ -1,0 +1,26 @@
+import { HttpClient } from '../http/http-client.js';
+import { LeadersResponse } from '../types/leaders.js';
+
+export class LeadersEndpoints {
+  constructor(private http: HttpClient) {}
+
+  async getSkatersCurrent(categories?: string): Promise<LeadersResponse> {
+    const params = categories ? { categories } : undefined;
+    return this.http.get<LeadersResponse>('/skater-stats-leaders/current', { params });
+  }
+
+  async getSkaters(season: string, gameType: number, categories?: string): Promise<LeadersResponse> {
+    const params = categories ? { categories } : undefined;
+    return this.http.get<LeadersResponse>(`/skater-stats-leaders/${season}/${gameType}`, { params });
+  }
+
+  async getGoaliesCurrent(categories?: string): Promise<LeadersResponse> {
+    const params = categories ? { categories } : undefined;
+    return this.http.get<LeadersResponse>('/goalie-stats-leaders/current', { params });
+  }
+
+  async getGoalies(season: string, gameType: number, categories?: string): Promise<LeadersResponse> {
+    const params = categories ? { categories } : undefined;
+    return this.http.get<LeadersResponse>(`/goalie-stats-leaders/${season}/${gameType}`, { params });
+  }
+}

--- a/src/web/players.ts
+++ b/src/web/players.ts
@@ -1,0 +1,22 @@
+import { HttpClient } from '../http/http-client.js';
+import { PlayerLanding, PlayerGameLog, PlayerSpotlight } from '../types/player.js';
+
+export class PlayersEndpoints {
+  constructor(private http: HttpClient) {}
+
+  async getLanding(playerId: number): Promise<PlayerLanding> {
+    return this.http.get<PlayerLanding>(`/player/${playerId}/landing`);
+  }
+
+  async getGameLog(playerId: number, season: string, gameType: number): Promise<PlayerGameLog> {
+    return this.http.get<PlayerGameLog>(`/player/${playerId}/game-log/${season}/${gameType}`);
+  }
+
+  async getGameLogNow(playerId: number): Promise<PlayerGameLog> {
+    return this.http.get<PlayerGameLog>(`/player/${playerId}/game-log/now`);
+  }
+
+  async getSpotlight(): Promise<PlayerSpotlight[]> {
+    return this.http.get<PlayerSpotlight[]>('/player-spotlight');
+  }
+}

--- a/src/web/schedule.ts
+++ b/src/web/schedule.ts
@@ -1,0 +1,25 @@
+import { HttpClient } from '../http/http-client.js';
+import { ScheduleResponse, ScheduleCalendar } from '../types/schedule.js';
+
+export class ScheduleEndpoints {
+  constructor(private http: HttpClient) {}
+
+  async get(date?: string): Promise<ScheduleResponse> {
+    const path = date ? `/schedule/${date}` : '/schedule/now';
+    return this.http.get<ScheduleResponse>(path);
+  }
+
+  async getCalendar(date?: string): Promise<ScheduleCalendar> {
+    const path = date ? `/schedule-calendar/${date}` : '/schedule-calendar/now';
+    return this.http.get<ScheduleCalendar>(path);
+  }
+
+  async getByTeam(teamAbbrev: string, date?: string): Promise<ScheduleResponse> {
+    const path = date ? `/schedule/${teamAbbrev}/${date}` : `/schedule/${teamAbbrev}/now`;
+    return this.http.get<ScheduleResponse>(path);
+  }
+
+  async getSeasonSchedule(season: string): Promise<unknown> {
+    return this.http.get(`/schedule/${season}`);
+  }
+}

--- a/src/web/scores.ts
+++ b/src/web/scores.ts
@@ -1,0 +1,21 @@
+import { HttpClient } from '../http/http-client.js';
+import { ScoresResponse } from '../types/game.js';
+import { TeamScoreboard } from '../types/team.js';
+
+export class ScoresEndpoints {
+  constructor(private http: HttpClient) {}
+
+  async get(date?: string): Promise<ScoresResponse> {
+    const path = date ? `/score/${date}` : '/score/now';
+    return this.http.get<ScoresResponse>(path);
+  }
+
+  async getScoreboard(date?: string): Promise<ScoresResponse> {
+    const path = date ? `/scoreboard/${date}` : '/scoreboard/now';
+    return this.http.get<ScoresResponse>(path);
+  }
+
+  async getTeamScoreboard(teamAbbrev: string): Promise<TeamScoreboard> {
+    return this.http.get<TeamScoreboard>(`/scoreboard/${teamAbbrev}/now`);
+  }
+}

--- a/src/web/standings.ts
+++ b/src/web/standings.ts
@@ -1,0 +1,15 @@
+import { HttpClient } from '../http/http-client.js';
+import { StandingsResponse, StandingsSeasonList } from '../types/standings.js';
+
+export class StandingsEndpoints {
+  constructor(private http: HttpClient) {}
+
+  async get(date?: string): Promise<StandingsResponse> {
+    const path = date ? `/standings/${date}` : '/standings/now';
+    return this.http.get<StandingsResponse>(path);
+  }
+
+  async getSeasonList(): Promise<StandingsSeasonList> {
+    return this.http.get<StandingsSeasonList>('/standings-season');
+  }
+}

--- a/src/web/teams.ts
+++ b/src/web/teams.ts
@@ -1,0 +1,65 @@
+import { HttpClient } from '../http/http-client.js';
+import { TeamRoster, TeamSeasonStats, TeamScheduleResponse, ProspectStats, TeamScoreboard } from '../types/team.js';
+
+export class TeamsEndpoints {
+  constructor(private http: HttpClient) {}
+
+  async getRoster(teamAbbrev: string, season?: string): Promise<TeamRoster> {
+    const path = season
+      ? `/roster/${teamAbbrev}/${season}`
+      : `/roster/${teamAbbrev}/current`;
+    return this.http.get<TeamRoster>(path);
+  }
+
+  async getRosterSeason(teamAbbrev: string): Promise<number[]> {
+    return this.http.get<number[]>(`/roster-season/${teamAbbrev}`);
+  }
+
+  async getStats(teamAbbrev: string, season?: string, gameType?: number): Promise<TeamSeasonStats> {
+    if (season && gameType !== undefined) {
+      return this.http.get<TeamSeasonStats>(`/club-stats/${teamAbbrev}/${season}/${gameType}`);
+    }
+    return this.http.get<TeamSeasonStats>(`/club-stats/${teamAbbrev}/now`);
+  }
+
+  async getStatsSeasonList(teamAbbrev: string): Promise<unknown> {
+    return this.http.get(`/club-stats-season/${teamAbbrev}`);
+  }
+
+  async getSchedule(teamAbbrev: string, month?: string): Promise<TeamScheduleResponse> {
+    const path = month
+      ? `/club-schedule/${teamAbbrev}/month/${month}`
+      : `/club-schedule/${teamAbbrev}/month/now`;
+    return this.http.get<TeamScheduleResponse>(path);
+  }
+
+  async getScheduleByWeek(teamAbbrev: string, date?: string): Promise<TeamScheduleResponse> {
+    const path = date
+      ? `/club-schedule/${teamAbbrev}/week/${date}`
+      : `/club-schedule/${teamAbbrev}/week/now`;
+    return this.http.get<TeamScheduleResponse>(path);
+  }
+
+  async getScheduleSeason(teamAbbrev: string, season?: string): Promise<TeamScheduleResponse> {
+    if (season) {
+      return this.http.get<TeamScheduleResponse>(`/club-schedule-season/${teamAbbrev}/${season}`);
+    }
+    return this.http.get<TeamScheduleResponse>(`/club-schedule-season/${teamAbbrev}/now`);
+  }
+
+  async getProspects(teamAbbrev: string): Promise<ProspectStats> {
+    return this.http.get<ProspectStats>(`/prospects/${teamAbbrev}`);
+  }
+
+  async getScoreboard(teamAbbrev: string): Promise<TeamScoreboard> {
+    return this.http.get<TeamScoreboard>(`/scoreboard/${teamAbbrev}/now`);
+  }
+
+  async getSeasonList(): Promise<unknown> {
+    return this.http.get('/season');
+  }
+
+  async getLogo(teamAbbrev: string): Promise<string> {
+    return this.http.get<string>(`/team/${teamAbbrev}/logo`);
+  }
+}

--- a/src/web/web-client.ts
+++ b/src/web/web-client.ts
@@ -1,4 +1,11 @@
 import { HttpClient } from '../http/http-client.js';
+import { PlayersEndpoints } from './players.js';
+import { StandingsEndpoints } from './standings.js';
+import { ScoresEndpoints } from './scores.js';
+import { TeamsEndpoints } from './teams.js';
+import { ScheduleEndpoints } from './schedule.js';
+import { GamesEndpoints } from './games.js';
+import { LeadersEndpoints } from './leaders.js';
 
 const WEB_API_BASE = 'https://api-web.nhle.com/v1';
 
@@ -10,6 +17,13 @@ export interface WebApiClientConfig {
 
 export class WebApiClient {
   private http: HttpClient;
+  public readonly players: PlayersEndpoints;
+  public readonly standings: StandingsEndpoints;
+  public readonly scores: ScoresEndpoints;
+  public readonly teams: TeamsEndpoints;
+  public readonly schedule: ScheduleEndpoints;
+  public readonly games: GamesEndpoints;
+  public readonly leaders: LeadersEndpoints;
 
   constructor(config?: WebApiClientConfig) {
     this.http = new HttpClient({
@@ -18,6 +32,14 @@ export class WebApiClient {
       retries: config?.retries,
       retryDelay: config?.retryDelay,
     });
+
+    this.players = new PlayersEndpoints(this.http);
+    this.standings = new StandingsEndpoints(this.http);
+    this.scores = new ScoresEndpoints(this.http);
+    this.teams = new TeamsEndpoints(this.http);
+    this.schedule = new ScheduleEndpoints(this.http);
+    this.games = new GamesEndpoints(this.http);
+    this.leaders = new LeadersEndpoints(this.http);
   }
 
   get httpClient(): HttpClient {

--- a/tests/unit/web-client.test.ts
+++ b/tests/unit/web-client.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import axios from 'axios';
+import { WebApiClient } from '../../src/web/web-client.js';
+
+vi.mock('axios');
+const mockAxios = vi.mocked(axios);
+
+describe('WebApiClient', () => {
+  let mockInstance: { get: ReturnType<typeof vi.fn> };
+  let client: WebApiClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInstance = { get: vi.fn().mockResolvedValue({ data: {} }) };
+    mockAxios.create.mockReturnValue(mockInstance as never);
+    mockAxios.isAxiosError.mockReturnValue(false);
+    client = new WebApiClient();
+  });
+
+  describe('players', () => {
+    it('getLanding calls correct path', async () => {
+      await client.players.getLanding(8478402);
+      expect(mockInstance.get).toHaveBeenCalledWith('/player/8478402/landing', expect.anything());
+    });
+
+    it('getGameLog calls correct path', async () => {
+      await client.players.getGameLog(8478402, '20232024', 2);
+      expect(mockInstance.get).toHaveBeenCalledWith('/player/8478402/game-log/20232024/2', expect.anything());
+    });
+
+    it('getGameLogNow calls correct path', async () => {
+      await client.players.getGameLogNow(8478402);
+      expect(mockInstance.get).toHaveBeenCalledWith('/player/8478402/game-log/now', expect.anything());
+    });
+
+    it('getSpotlight calls correct path', async () => {
+      await client.players.getSpotlight();
+      expect(mockInstance.get).toHaveBeenCalledWith('/player-spotlight', expect.anything());
+    });
+  });
+
+  describe('standings', () => {
+    it('get without date calls /standings/now', async () => {
+      await client.standings.get();
+      expect(mockInstance.get).toHaveBeenCalledWith('/standings/now', expect.anything());
+    });
+
+    it('get with date calls /standings/{date}', async () => {
+      await client.standings.get('2024-01-15');
+      expect(mockInstance.get).toHaveBeenCalledWith('/standings/2024-01-15', expect.anything());
+    });
+  });
+
+  describe('scores', () => {
+    it('get without date calls /score/now', async () => {
+      await client.scores.get();
+      expect(mockInstance.get).toHaveBeenCalledWith('/score/now', expect.anything());
+    });
+  });
+
+  describe('teams', () => {
+    it('getRoster calls correct path', async () => {
+      await client.teams.getRoster('TOR');
+      expect(mockInstance.get).toHaveBeenCalledWith('/roster/TOR/current', expect.anything());
+    });
+
+    it('getRoster with season calls correct path', async () => {
+      await client.teams.getRoster('TOR', '20232024');
+      expect(mockInstance.get).toHaveBeenCalledWith('/roster/TOR/20232024', expect.anything());
+    });
+
+    it('getStats now calls correct path', async () => {
+      await client.teams.getStats('TOR');
+      expect(mockInstance.get).toHaveBeenCalledWith('/club-stats/TOR/now', expect.anything());
+    });
+
+    it('getSchedule calls correct path', async () => {
+      await client.teams.getSchedule('TOR');
+      expect(mockInstance.get).toHaveBeenCalledWith('/club-schedule/TOR/month/now', expect.anything());
+    });
+  });
+
+  describe('schedule', () => {
+    it('get without date calls /schedule/now', async () => {
+      await client.schedule.get();
+      expect(mockInstance.get).toHaveBeenCalledWith('/schedule/now', expect.anything());
+    });
+  });
+
+  describe('games', () => {
+    it('getPlayByPlay calls correct path', async () => {
+      await client.games.getPlayByPlay(2024020001);
+      expect(mockInstance.get).toHaveBeenCalledWith('/gamecenter/2024020001/play-by-play', expect.anything());
+    });
+
+    it('getBoxscore calls correct path', async () => {
+      await client.games.getBoxscore(2024020001);
+      expect(mockInstance.get).toHaveBeenCalledWith('/gamecenter/2024020001/boxscore', expect.anything());
+    });
+  });
+
+  describe('leaders', () => {
+    it('getSkatersCurrent calls correct path', async () => {
+      await client.leaders.getSkatersCurrent();
+      expect(mockInstance.get).toHaveBeenCalledWith('/skater-stats-leaders/current', expect.anything());
+    });
+
+    it('getGoaliesCurrent calls correct path', async () => {
+      await client.leaders.getGoaliesCurrent();
+      expect(mockInstance.get).toHaveBeenCalledWith('/goalie-stats-leaders/current', expect.anything());
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 7 endpoint modules: players, standings, scores, teams, schedule, games, leaders
- Full TypeScript types for all response shapes
- Convenience access via `nhl.players`, `nhl.standings`, etc.
- 23 tests passing (16 new + 7 existing)

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` produces CJS + ESM + .d.ts
- [x] `npm run test` - 23 unit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)