### PR TITLE
feat: extended Web API endpoints and NHL Edge analytics

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -6,6 +6,10 @@ import { TeamsEndpoints } from './web/teams.js';
 import { ScheduleEndpoints } from './web/schedule.js';
 import { GamesEndpoints } from './web/games.js';
 import { LeadersEndpoints } from './web/leaders.js';
+import { DraftEndpoints } from './web/draft.js';
+import { PlayoffsEndpoints } from './web/playoffs.js';
+import { NetworkEndpoints } from './web/network.js';
+import { MetaEndpoints } from './web/meta.js';
 
 export interface NHLClientConfig extends WebApiClientConfig {}
 
@@ -18,6 +22,10 @@ export class NHLClient {
   public readonly schedule: ScheduleEndpoints;
   public readonly games: GamesEndpoints;
   public readonly leaders: LeadersEndpoints;
+  public readonly draft: DraftEndpoints;
+  public readonly playoffs: PlayoffsEndpoints;
+  public readonly network: NetworkEndpoints;
+  public readonly meta: MetaEndpoints;
 
   constructor(config?: NHLClientConfig) {
     this.web = new WebApiClient(config);
@@ -28,5 +36,9 @@ export class NHLClient {
     this.schedule = this.web.schedule;
     this.games = this.web.games;
     this.leaders = this.web.leaders;
+    this.draft = this.web.draft;
+    this.playoffs = this.web.playoffs;
+    this.network = this.web.network;
+    this.meta = this.web.meta;
   }
 }

--- a/src/types/draft.ts
+++ b/src/types/draft.ts
@@ -1,0 +1,63 @@
+import { LocalizedName } from './common.js';
+
+export interface DraftRankingsResponse {
+  draftYear: number;
+  categoryKey: string;
+  categories: DraftCategory[];
+  rankings: DraftProspect[];
+}
+
+export interface DraftCategory {
+  categoryKey: string;
+  categoryName: string;
+}
+
+export interface DraftProspect {
+  lastName: string;
+  firstName: string;
+  positionCode: string;
+  shootsCatches?: string;
+  heightInInches?: number;
+  weightInPounds?: number;
+  lastAmateurClub?: string;
+  lastAmateurLeague?: string;
+  birthDate: string;
+  birthCity?: string;
+  birthStateProvince?: string;
+  birthCountry?: string;
+  midtermRank?: number;
+  finalRank?: number;
+  [key: string]: unknown;
+}
+
+export interface DraftPicksResponse {
+  draftYear: number;
+  rounds: DraftRound[];
+}
+
+export interface DraftRound {
+  roundNumber: number;
+  picks: DraftPick[];
+}
+
+export interface DraftPick {
+  round: number;
+  pickInRound: number;
+  overallPickNumber: number;
+  year: number;
+  teamAbbrev: string;
+  teamLogo: string;
+  firstName: string;
+  lastName: string;
+  positionCode: string;
+  shootsCatches?: string;
+  birthDate?: string;
+  birthCity?: string;
+  birthCountry?: string;
+  heightInInches?: number;
+  weightInPounds?: number;
+  amateurClubName?: string;
+  amateurLeague?: string;
+  playerId?: number;
+  [key: string]: unknown;
+}

--- a/src/types/edge.ts
+++ b/src/types/edge.ts
@@ -1,0 +1,40 @@
+export interface EdgeSeasonParams {
+  season?: string;
+  gameType?: number;
+  position?: string;
+  team?: string;
+  limit?: number;
+  start?: number;
+}
+
+export interface EdgeTeamStat {
+  teamId: number;
+  teamFullName: string;
+  teamAbbrev: string;
+  gamesPlayed: number;
+  [key: string]: unknown;
+}
+
+export interface EdgeSkaterStat {
+  playerId: number;
+  firstName: string;
+  lastName: string;
+  teamAbbrev: string;
+  position: string;
+  gamesPlayed: number;
+  [key: string]: unknown;
+}
+
+export interface EdgeGoalieStat {
+  playerId: number;
+  firstName: string;
+  lastName: string;
+  teamAbbrev: string;
+  gamesPlayed: number;
+  [key: string]: unknown;
+}
+
+export interface EdgeResponse<T> {
+  data: T[];
+  total: number;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,3 +5,6 @@ export * from './schedule.js';
 export * from './game.js';
 export * from './team.js';
 export * from './leaders.js';
+export * from './draft.js';
+export * from './playoffs.js';
+export * from './edge.js';

--- a/src/types/playoffs.ts
+++ b/src/types/playoffs.ts
@@ -1,0 +1,95 @@
+import { LocalizedName } from './common.js';
+
+export interface PlayoffSeriesCarousel {
+  seasonId: number;
+  currentRound: number;
+  rounds: PlayoffRound[];
+}
+
+export interface PlayoffRound {
+  roundNumber: number;
+  roundCode: string;
+  roundAbbrev: string;
+  series: PlayoffSeries[];
+}
+
+export interface PlayoffSeries {
+  seriesTitle: string;
+  seriesAbbrev: string;
+  seriesLetter: string;
+  seriesUrl: string;
+  topSeedTeam: PlayoffTeam;
+  bottomSeedTeam: PlayoffTeam;
+  winningTeamId?: number;
+  losingTeamId?: number;
+  neededToWin: number;
+  topSeedWins: number;
+  bottomSeedWins: number;
+}
+
+export interface PlayoffTeam {
+  id: number;
+  abbrev: string;
+  name: LocalizedName;
+  logo: string;
+  darkLogo?: string;
+  commonName?: LocalizedName;
+  seed?: number;
+  seriesWins?: number;
+}
+
+export interface PlayoffSeriesSchedule {
+  seriesTitle: string;
+  topSeedTeam: PlayoffTeam;
+  bottomSeedTeam: PlayoffTeam;
+  games: PlayoffGame[];
+}
+
+export interface PlayoffGame {
+  id: number;
+  season: number;
+  gameType: number;
+  gameDate: string;
+  venue: LocalizedName;
+  startTimeUTC: string;
+  gameState: string;
+  gameScheduleState: string;
+  seriesGameNumber: number;
+  awayTeam: PlayoffGameTeam;
+  homeTeam: PlayoffGameTeam;
+  periodDescriptor?: { number: number; periodType: string };
+  gameOutcome?: { lastPeriodType: string };
+  [key: string]: unknown;
+}
+
+export interface PlayoffGameTeam {
+  id: number;
+  abbrev: string;
+  logo: string;
+  score?: number;
+}
+
+export interface PlayoffBracket {
+  seasonId: number;
+  rounds: PlayoffBracketRound[];
+}
+
+export interface PlayoffBracketRound {
+  roundNumber: number;
+  roundCode: string;
+  roundAbbrev: string;
+  series: PlayoffBracketSeries[];
+}
+
+export interface PlayoffBracketSeries {
+  seriesTitle: string;
+  seriesLetter: string;
+  matchup: {
+    topSeed: PlayoffTeam;
+    bottomSeed: PlayoffTeam;
+  };
+  winningTeamId?: number;
+  topSeedWins: number;
+  bottomSeedWins: number;
+  [key: string]: unknown;
+}

--- a/src/web/draft.ts
+++ b/src/web/draft.ts
@@ -1,0 +1,26 @@
+import { HttpClient } from '../http/http-client.js';
+import { DraftRankingsResponse, DraftPicksResponse } from '../types/draft.js';
+
+export class DraftEndpoints {
+  constructor(private http: HttpClient) {}
+
+  async getRankingsNow(): Promise<DraftRankingsResponse> {
+    return this.http.get<DraftRankingsResponse>('/draft/rankings/now');
+  }
+
+  async getRankings(season: string, prospectCategory?: string): Promise<DraftRankingsResponse> {
+    const params = prospectCategory ? { prospectCategory } : undefined;
+    return this.http.get<DraftRankingsResponse>(`/draft/rankings/${season}`, { params });
+  }
+
+  async getPicksNow(): Promise<DraftPicksResponse> {
+    return this.http.get<DraftPicksResponse>('/draft/picks/now');
+  }
+
+  async getPicks(season: string, round?: number): Promise<DraftPicksResponse> {
+    if (round !== undefined) {
+      return this.http.get<DraftPicksResponse>(`/draft/picks/${season}/round/${round}`);
+    }
+    return this.http.get<DraftPicksResponse>(`/draft/picks/${season}`);
+  }
+}

--- a/src/web/edge/edge-goalies.ts
+++ b/src/web/edge/edge-goalies.ts
@@ -1,0 +1,61 @@
+import { HttpClient } from '../../http/http-client.js';
+import { EdgeGoalieStat, EdgeSeasonParams, EdgeResponse } from '../../types/edge.js';
+
+export class EdgeGoaliesEndpoints {
+  constructor(private http: HttpClient) {}
+
+  private buildParams(params?: EdgeSeasonParams): Record<string, string | number | boolean | undefined> | undefined {
+    if (!params) return undefined;
+    const result: Record<string, string | number | boolean | undefined> = {};
+    if (params.season) result.season = params.season;
+    if (params.gameType !== undefined) result.gameType = params.gameType;
+    if (params.team) result.team = params.team;
+    if (params.limit !== undefined) result.limit = params.limit;
+    if (params.start !== undefined) result.start = params.start;
+    return Object.keys(result).length > 0 ? result : undefined;
+  }
+
+  async getRealTimeStats(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeGoalieStat>> {
+    return this.http.get('/edge/goalie/stats/real-time', { params: this.buildParams(params) });
+  }
+
+  async getSaveTracking(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeGoalieStat>> {
+    return this.http.get('/edge/goalie/stats/save-tracking', { params: this.buildParams(params) });
+  }
+
+  async getShotSpeed(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeGoalieStat>> {
+    return this.http.get('/edge/goalie/stats/shot-speed', { params: this.buildParams(params) });
+  }
+
+  async getShotLocation(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeGoalieStat>> {
+    return this.http.get('/edge/goalie/stats/shot-location', { params: this.buildParams(params) });
+  }
+
+  async getShotType(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeGoalieStat>> {
+    return this.http.get('/edge/goalie/stats/shot-type', { params: this.buildParams(params) });
+  }
+
+  async getZoneTime(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeGoalieStat>> {
+    return this.http.get('/edge/goalie/stats/zone-time', { params: this.buildParams(params) });
+  }
+
+  async getPenaltyKill(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeGoalieStat>> {
+    return this.http.get('/edge/goalie/stats/penalty-kill', { params: this.buildParams(params) });
+  }
+
+  async getStartVsRelief(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeGoalieStat>> {
+    return this.http.get('/edge/goalie/stats/start-vs-relief', { params: this.buildParams(params) });
+  }
+
+  async getDaysRest(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeGoalieStat>> {
+    return this.http.get('/edge/goalie/stats/days-rest', { params: this.buildParams(params) });
+  }
+
+  async getOverview(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeGoalieStat>> {
+    return this.http.get('/edge/goalie/stats/overview', { params: this.buildParams(params) });
+  }
+
+  async getLeaders(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeGoalieStat>> {
+    return this.http.get('/edge/goalie/stats/leaders', { params: this.buildParams(params) });
+  }
+}

--- a/src/web/edge/edge-skaters.ts
+++ b/src/web/edge/edge-skaters.ts
@@ -1,0 +1,78 @@
+import { HttpClient } from '../../http/http-client.js';
+import { EdgeSkaterStat, EdgeSeasonParams, EdgeResponse } from '../../types/edge.js';
+
+export class EdgeSkatersEndpoints {
+  constructor(private http: HttpClient) {}
+
+  private buildParams(params?: EdgeSeasonParams): Record<string, string | number | boolean | undefined> | undefined {
+    if (!params) return undefined;
+    const result: Record<string, string | number | boolean | undefined> = {};
+    if (params.season) result.season = params.season;
+    if (params.gameType !== undefined) result.gameType = params.gameType;
+    if (params.position) result.position = params.position;
+    if (params.team) result.team = params.team;
+    if (params.limit !== undefined) result.limit = params.limit;
+    if (params.start !== undefined) result.start = params.start;
+    return Object.keys(result).length > 0 ? result : undefined;
+  }
+
+  async getRealTimeStats(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeSkaterStat>> {
+    return this.http.get('/edge/skater/stats/real-time', { params: this.buildParams(params) });
+  }
+
+  async getDistance(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeSkaterStat>> {
+    return this.http.get('/edge/skater/stats/distance', { params: this.buildParams(params) });
+  }
+
+  async getSpeed(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeSkaterStat>> {
+    return this.http.get('/edge/skater/stats/speed', { params: this.buildParams(params) });
+  }
+
+  async getSpeedBursts(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeSkaterStat>> {
+    return this.http.get('/edge/skater/stats/speed-bursts', { params: this.buildParams(params) });
+  }
+
+  async getZoneTime(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeSkaterStat>> {
+    return this.http.get('/edge/skater/stats/zone-time', { params: this.buildParams(params) });
+  }
+
+  async getShotSpeed(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeSkaterStat>> {
+    return this.http.get('/edge/skater/stats/shot-speed', { params: this.buildParams(params) });
+  }
+
+  async getShotLocation(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeSkaterStat>> {
+    return this.http.get('/edge/skater/stats/shot-location', { params: this.buildParams(params) });
+  }
+
+  async getTimeBetweenShots(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeSkaterStat>> {
+    return this.http.get('/edge/skater/stats/time-between-shots', { params: this.buildParams(params) });
+  }
+
+  async getPossessionTime(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeSkaterStat>> {
+    return this.http.get('/edge/skater/stats/possession-time', { params: this.buildParams(params) });
+  }
+
+  async getPenaltyKill(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeSkaterStat>> {
+    return this.http.get('/edge/skater/stats/penalty-kill', { params: this.buildParams(params) });
+  }
+
+  async getPowerPlay(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeSkaterStat>> {
+    return this.http.get('/edge/skater/stats/power-play', { params: this.buildParams(params) });
+  }
+
+  async getFaceoffs(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeSkaterStat>> {
+    return this.http.get('/edge/skater/stats/faceoffs', { params: this.buildParams(params) });
+  }
+
+  async getOverview(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeSkaterStat>> {
+    return this.http.get('/edge/skater/stats/overview', { params: this.buildParams(params) });
+  }
+
+  async getRealtimeLeaders(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeSkaterStat>> {
+    return this.http.get('/edge/skater/stats/leaders/real-time', { params: this.buildParams(params) });
+  }
+
+  async getSpeedLeaders(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeSkaterStat>> {
+    return this.http.get('/edge/skater/stats/leaders/speed', { params: this.buildParams(params) });
+  }
+}

--- a/src/web/edge/edge-teams.ts
+++ b/src/web/edge/edge-teams.ts
@@ -1,0 +1,68 @@
+import { HttpClient } from '../../http/http-client.js';
+import { EdgeTeamStat, EdgeSeasonParams, EdgeResponse } from '../../types/edge.js';
+
+export class EdgeTeamsEndpoints {
+  constructor(private http: HttpClient) {}
+
+  private buildParams(params?: EdgeSeasonParams): Record<string, string | number | boolean | undefined> | undefined {
+    if (!params) return undefined;
+    const result: Record<string, string | number | boolean | undefined> = {};
+    if (params.season) result.season = params.season;
+    if (params.gameType !== undefined) result.gameType = params.gameType;
+    if (params.limit !== undefined) result.limit = params.limit;
+    if (params.start !== undefined) result.start = params.start;
+    return Object.keys(result).length > 0 ? result : undefined;
+  }
+
+  async getRealTimeStats(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeTeamStat>> {
+    return this.http.get('/edge/team/stats/real-time', { params: this.buildParams(params) });
+  }
+
+  async getDistance(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeTeamStat>> {
+    return this.http.get('/edge/team/stats/distance', { params: this.buildParams(params) });
+  }
+
+  async getSpeed(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeTeamStat>> {
+    return this.http.get('/edge/team/stats/speed', { params: this.buildParams(params) });
+  }
+
+  async getSpeedBursts(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeTeamStat>> {
+    return this.http.get('/edge/team/stats/speed-bursts', { params: this.buildParams(params) });
+  }
+
+  async getZoneTime(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeTeamStat>> {
+    return this.http.get('/edge/team/stats/zone-time', { params: this.buildParams(params) });
+  }
+
+  async getShotSpeed(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeTeamStat>> {
+    return this.http.get('/edge/team/stats/shot-speed', { params: this.buildParams(params) });
+  }
+
+  async getShotLocation(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeTeamStat>> {
+    return this.http.get('/edge/team/stats/shot-location', { params: this.buildParams(params) });
+  }
+
+  async getTimeBetweenShots(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeTeamStat>> {
+    return this.http.get('/edge/team/stats/time-between-shots', { params: this.buildParams(params) });
+  }
+
+  async getPossessionTime(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeTeamStat>> {
+    return this.http.get('/edge/team/stats/possession-time', { params: this.buildParams(params) });
+  }
+
+  async getPenaltyKill(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeTeamStat>> {
+    return this.http.get('/edge/team/stats/penalty-kill', { params: this.buildParams(params) });
+  }
+
+  async getPowerPlay(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeTeamStat>> {
+    return this.http.get('/edge/team/stats/power-play', { params: this.buildParams(params) });
+  }
+
+  async getFaceoffs(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeTeamStat>> {
+    return this.http.get('/edge/team/stats/faceoffs', { params: this.buildParams(params) });
+  }
+
+  async getOverview(params?: EdgeSeasonParams): Promise<EdgeResponse<EdgeTeamStat>> {
+    return this.http.get('/edge/team/stats/overview', { params: this.buildParams(params) });
+  }
+}

--- a/src/web/meta.ts
+++ b/src/web/meta.ts
@@ -1,0 +1,54 @@
+import { HttpClient } from '../http/http-client.js';
+
+export interface MetaResponse {
+  players: MetaPlayer[];
+  teams: MetaTeam[];
+  seasonStates: MetaSeasonState[];
+}
+
+export interface MetaPlayer {
+  playerId: number;
+  name: string;
+  teamId: number;
+  teamAbbrev: string;
+  position: string;
+}
+
+export interface MetaTeam {
+  teamId: number;
+  teamAbbrev: string;
+  teamFullName: string;
+}
+
+export interface MetaSeasonState {
+  seasonId: number;
+  gameTypes: number[];
+}
+
+export interface GameMetaResponse {
+  [key: string]: unknown;
+}
+
+export class MetaEndpoints {
+  constructor(private http: HttpClient) {}
+
+  async get(): Promise<MetaResponse> {
+    return this.http.get<MetaResponse>('/meta');
+  }
+
+  async getGame(gameId: number): Promise<GameMetaResponse> {
+    return this.http.get<GameMetaResponse>(`/meta/game/${gameId}`);
+  }
+
+  async getLocation(): Promise<unknown> {
+    return this.http.get('/location');
+  }
+
+  async getSeason(): Promise<unknown> {
+    return this.http.get('/season');
+  }
+
+  async getPlayoffSeriesMeta(): Promise<unknown> {
+    return this.http.get('/meta/playoff-series');
+  }
+}

--- a/src/web/network.ts
+++ b/src/web/network.ts
@@ -1,0 +1,38 @@
+import { HttpClient } from '../http/http-client.js';
+
+export interface TvScheduleResponse {
+  date: string;
+  games: TvScheduleGame[];
+}
+
+export interface TvScheduleGame {
+  id: number;
+  startTimeUTC: string;
+  awayTeam: { abbrev: string; logo: string };
+  homeTeam: { abbrev: string; logo: string };
+  tvBroadcasts: { network: string; market: string; countryCode: string }[];
+  [key: string]: unknown;
+}
+
+export interface WhereToWatchResponse {
+  [key: string]: unknown;
+}
+
+export class NetworkEndpoints {
+  constructor(private http: HttpClient) {}
+
+  async getTvSchedule(date?: string): Promise<TvScheduleResponse> {
+    const path = date ? `/network/tv-schedule/${date}` : '/network/tv-schedule/now';
+    return this.http.get<TvScheduleResponse>(path);
+  }
+
+  async getWhereToWatch(): Promise<WhereToWatchResponse> {
+    return this.http.get<WhereToWatchResponse>('/where-to-watch');
+  }
+
+  async getPartnerGames(countryCode: string, date?: string): Promise<unknown> {
+    const params: Record<string, string> = { country: countryCode };
+    if (date) params.date = date;
+    return this.http.get('/partner-game/now', { params });
+  }
+}

--- a/src/web/playoffs.ts
+++ b/src/web/playoffs.ts
@@ -1,0 +1,20 @@
+import { HttpClient } from '../http/http-client.js';
+import { PlayoffSeriesCarousel, PlayoffSeriesSchedule, PlayoffBracket } from '../types/playoffs.js';
+
+export class PlayoffsEndpoints {
+  constructor(private http: HttpClient) {}
+
+  async getSeriesCarousel(season?: string): Promise<PlayoffSeriesCarousel> {
+    const path = season ? `/playoff-series/carousel/${season}` : '/playoff-series/carousel/now';
+    return this.http.get<PlayoffSeriesCarousel>(path);
+  }
+
+  async getSeriesSchedule(season: string, seriesLetter: string): Promise<PlayoffSeriesSchedule> {
+    return this.http.get<PlayoffSeriesSchedule>(`/playoff-series/schedule/${season}/${seriesLetter}`);
+  }
+
+  async getBracket(season?: string): Promise<PlayoffBracket> {
+    const path = season ? `/playoff-bracket/${season}` : '/playoff-bracket/now';
+    return this.http.get<PlayoffBracket>(path);
+  }
+}

--- a/src/web/web-client.ts
+++ b/src/web/web-client.ts
@@ -6,6 +6,13 @@ import { TeamsEndpoints } from './teams.js';
 import { ScheduleEndpoints } from './schedule.js';
 import { GamesEndpoints } from './games.js';
 import { LeadersEndpoints } from './leaders.js';
+import { DraftEndpoints } from './draft.js';
+import { PlayoffsEndpoints } from './playoffs.js';
+import { NetworkEndpoints } from './network.js';
+import { MetaEndpoints } from './meta.js';
+import { EdgeTeamsEndpoints } from './edge/edge-teams.js';
+import { EdgeSkatersEndpoints } from './edge/edge-skaters.js';
+import { EdgeGoaliesEndpoints } from './edge/edge-goalies.js';
 
 const WEB_API_BASE = 'https://api-web.nhle.com/v1';
 
@@ -24,6 +31,15 @@ export class WebApiClient {
   public readonly schedule: ScheduleEndpoints;
   public readonly games: GamesEndpoints;
   public readonly leaders: LeadersEndpoints;
+  public readonly draft: DraftEndpoints;
+  public readonly playoffs: PlayoffsEndpoints;
+  public readonly network: NetworkEndpoints;
+  public readonly meta: MetaEndpoints;
+  public readonly edge: {
+    teams: EdgeTeamsEndpoints;
+    skaters: EdgeSkatersEndpoints;
+    goalies: EdgeGoaliesEndpoints;
+  };
 
   constructor(config?: WebApiClientConfig) {
     this.http = new HttpClient({
@@ -40,6 +56,15 @@ export class WebApiClient {
     this.schedule = new ScheduleEndpoints(this.http);
     this.games = new GamesEndpoints(this.http);
     this.leaders = new LeadersEndpoints(this.http);
+    this.draft = new DraftEndpoints(this.http);
+    this.playoffs = new PlayoffsEndpoints(this.http);
+    this.network = new NetworkEndpoints(this.http);
+    this.meta = new MetaEndpoints(this.http);
+    this.edge = {
+      teams: new EdgeTeamsEndpoints(this.http),
+      skaters: new EdgeSkatersEndpoints(this.http),
+      goalies: new EdgeGoaliesEndpoints(this.http),
+    };
   }
 
   get httpClient(): HttpClient {


### PR DESCRIPTION
## Summary
- Adds draft, playoffs, network, and meta endpoint modules
- Full NHL Edge analytics: 39 endpoints across teams, skaters, goalies (speed, distance, zone time, shot speed, shot location, possession, faceoffs, and more)
- Types for draft prospects/picks, playoff brackets/series, and Edge stats
- All wired into WebApiClient and NHLClient convenience layer

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` produces CJS + ESM + .d.ts
- [x] `npm run test` - 23 unit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)